### PR TITLE
Consistently pass by const ref wherever possible

### DIFF
--- a/include/phase_finder.hpp
+++ b/include/phase_finder.hpp
@@ -96,15 +96,15 @@ class PhaseFinder {
      over a uniform interval in field space
   */
   std::vector<Eigen::VectorXd> generate_test_points() const;
-  std::vector<Point> find_minima_at_t(std::vector<Eigen::VectorXd> test_points, double T) const;
+  std::vector<Point> find_minima_at_t(const std::vector<Eigen::VectorXd>& test_points, double T) const;
 
   void find_phases();
 
-  double delta_potential_at_T(const Phase *phase1, const Phase *phase2, double T) const {
+  double delta_potential_at_T(const Phase& phase1, const Phase& phase2, double T) const {
     return phase_at_T(phase1, T).potential - phase_at_T(phase2, T).potential;
   }
 
-  Point phase_at_T(const Phase *phase, double T) const;
+  Point phase_at_T(const Phase& phase, double T) const;
 
   /** Pretty-printer for a collection of phases */
   friend std::ostream& operator << (std::ostream& o, const PhaseFinder& pf) {
@@ -136,10 +136,10 @@ class PhaseFinder {
   }
 
   /** Generate symmetric partner for a point */
-  std::vector<Eigen::VectorXd> symmetric_partners(const Eigen::VectorXd a) const;
+  std::vector<Eigen::VectorXd> symmetric_partners(const Eigen::VectorXd& a) const;
   
   /** Check that two minima are identical to within a particular tolerance */
-  bool identical_within_tol(const Eigen::VectorXd a, const Eigen::VectorXd b) const;
+  bool identical_within_tol(const Eigen::VectorXd& a, const Eigen::VectorXd& b) const;
 
   /** return minima at T_low*/
   std::vector<Point> get_minima_at_t_low();
@@ -153,23 +153,23 @@ class PhaseFinder {
      Find local minima at a particular temperature. The overloads define
      different ways of passing an initial step.
   */
-  Point find_min(const Eigen::VectorXd X, double T, double step) const;
-  Point find_min(const Eigen::VectorXd X, double T, Eigen::VectorXd step) const;
-  Point find_min(const Eigen::VectorXd X, double T) const;
+  Point find_min(const Eigen::VectorXd& X, double T, double step) const;
+  Point find_min(const Eigen::VectorXd& X, double T, Eigen::VectorXd step) const;
+  Point find_min(const Eigen::VectorXd& X, double T) const;
 
   /** Check for a jump discontinuity between two phases*/
-  bool jump(const Eigen::VectorXd a, const Eigen::VectorXd b) const;
+  bool jump(const Eigen::VectorXd& a, const Eigen::VectorXd& b) const;
   /** Get descriptor of a particular minimum */
-  minima_descriptor get_minima_descriptor(const Point minima) const;
+  minima_descriptor get_minima_descriptor(const Point& minima) const;
   /**
     @overload
     Get descriptor of the deepest minimum of a set at a particular temperature
   */
-  minima_descriptor get_minima_descriptor(const std::vector<Point> minima, double T) const;
+  minima_descriptor get_minima_descriptor(const std::vector<Point>& minima, double T) const;
   /** Get deepest minimum of a set at a particular temperature */
-  Point get_deepest_minima(const std::vector<Point> minima, double T) const;
+  Point get_deepest_minima(const std::vector<Point>& minima, double T) const;
   /** Check whether the origin is the unique minima */
-  bool origin_unique_minima(const std::vector<Point> minima) const;
+  bool origin_unique_minima(const std::vector<Point>& minima) const;
 
   static double wrap_nlopt(const std::vector<double> &x,
                            std::vector<double> &grad, void *data) {
@@ -187,34 +187,34 @@ class PhaseFinder {
   std::vector<Point> minima_at_t_high;
 
   /** Expected change in minimum with temperature, dx/dt */
-  Eigen::VectorXd dx_min_dt(Eigen::VectorXd X, double T) const;
+  Eigen::VectorXd dx_min_dt(const Eigen::VectorXd& X, double T) const;
   /** @overload Precomputed Hessian matrix */
-  Eigen::VectorXd dx_min_dt(Eigen::MatrixXd hessian, Eigen::VectorXd X, double T) const;
+  Eigen::VectorXd dx_min_dt(const Eigen::MatrixXd& hessian, const Eigen::VectorXd& X, double T) const;
 
   /** Check whether two phases are redundant */
-  bool redundant(const Phase *phase1, const Phase *phase2, end_descriptor end = BOTH) const;
+  bool redundant(const Phase& phase1, const Phase& phase2, end_descriptor end = BOTH) const;
 
   /** Check whether point belongs to a known phase */
-  bool belongs_known_phase(Point point) const;
+  bool belongs_known_phase(const Point& point) const;
 
   /** Electroweak vacuum at zero temperature */
-  bool consistent_vacuum(Eigen::VectorXd x) const;
+  bool consistent_vacuum(const Eigen::VectorXd& x) const;
 
   /** Check whether point is out of boundary */
-  bool out_of_bounds(Eigen::VectorXd x) const;
+  bool out_of_bounds(const Eigen::VectorXd& x) const;
 
   /** Remove/combine identical phases */
   void remove_redundant();
 
   /** Check whether Hessian is singular */
-  bool hessian_singular(Eigen::VectorXd X, double T) const;
+  bool hessian_singular(const Eigen::VectorXd& X, double T) const;
   /** @overload Precomputed Hessian matrix */
-  bool hessian_singular(Eigen::MatrixXd hessian, Eigen::VectorXd X, double T) const;
+  bool hessian_singular(const Eigen::MatrixXd& hessian, const Eigen::VectorXd& X, double T) const;
 
   /** Check whether Hessian is positive definite  */
-  bool hessian_positive_definite(Eigen::VectorXd X, double T) const;
+  bool hessian_positive_definite(const Eigen::VectorXd& X, double T) const;
   /** @overload Precomputed Hessian matrix */
-  bool hessian_positive_definite(Eigen::MatrixXd hessian, Eigen::VectorXd X, double T) const;
+  bool hessian_positive_definite(const Eigen::MatrixXd& hessian, const Eigen::VectorXd& X, double T) const;
 
   /** Default bound on fields */
   const double bound = 1600.;

--- a/include/phase_plotter.hpp
+++ b/include/phase_plotter.hpp
@@ -29,7 +29,7 @@
 
 namespace PhaseTracer {
 
-void phase_plotter(PhaseTracer::TransitionFinder tf, std::string prefix = "model") {
+void phase_plotter(const PhaseTracer::TransitionFinder& tf, std::string prefix = "model") {
   std::ofstream output_file;
   output_file.open(prefix + ".dat");
 

--- a/include/potential_line_plotter.hpp
+++ b/include/potential_line_plotter.hpp
@@ -31,7 +31,10 @@
 
 namespace PhaseTracer {
 
-void potential_line_plotter(EffectivePotential::Potential &P, double T, Eigen::VectorXd false_vacuum, Eigen::VectorXd true_vacuum, std::string prefix = "model") {
+void potential_line_plotter(const EffectivePotential::Potential &P, double T, 
+                            const Eigen::VectorXd& false_vacuum,
+                            const Eigen::VectorXd& true_vacuum,
+                            std::string prefix = "model") {
 
   std::ofstream output_file;
   const auto dat_name = prefix + "_potential_line.dat";

--- a/include/potential_plotter.hpp
+++ b/include/potential_plotter.hpp
@@ -31,7 +31,7 @@
 
 namespace PhaseTracer {
 
-void potential_plotter(EffectivePotential::Potential &P,
+void potential_plotter(const EffectivePotential::Potential& P,
                        double T,
                        std::string prefix = "model",
                        double xmin = -100.,

--- a/include/transition_finder.hpp
+++ b/include/transition_finder.hpp
@@ -71,7 +71,7 @@ struct Transition {
 
 class TransitionFinder {
  public:
-  explicit TransitionFinder(PhaseFinder &pf_);
+  explicit TransitionFinder(PhaseFinder& pf_) : pf(pf_) {}
   virtual ~TransitionFinder() = default;
 
   /** Find all transitions between all phases */

--- a/include/transition_finder.hpp
+++ b/include/transition_finder.hpp
@@ -100,19 +100,19 @@ class TransitionFinder {
   std::vector<Transition> find_transition(Phase p1, Phase p2, double T1, double T2) const;
 
   /** Find many transitions between two phases at a particular resolution */
-  std::vector<Transition> divide_and_find_transition(Phase phase1, Phase phase2, double T1, double T2) const;
+  std::vector<Transition> divide_and_find_transition(const Phase& phase1, const Phase& phase2, double T1, double T2) const;
 
   /** Check whether two phase are overlapped at T*/
-  bool phases_overlaped(Phase phase1, Phase phase2, double T) const;
+  bool phases_overlaped(const Phase& phase1, const Phase& phase2, double T) const;
 
   /** Find un-overlapped temperature region between the two phases*/
-  std::vector<double> get_un_overlapped_T_range(Phase phase1, Phase phase2, double T1, double T2) const;
+  std::vector<double> get_un_overlapped_T_range(const Phase& phase1, const Phase& phase2, double T1, double T2) const;
 
   /** Strength of phase transition for first N fields */
-  double gamma(const Eigen::VectorXd true_vacuum, const Eigen::VectorXd false_vacuum, const double TC) const;
+  double gamma(const Eigen::VectorXd& true_vacuum, const Eigen::VectorXd& false_vacuum, const double TC) const;
 
   /** Note which VEVs changed */
-  std::vector<bool> changed(const Eigen::VectorXd true_vacuum, const Eigen::VectorXd false_vacuum) const;
+  std::vector<bool> changed(const Eigen::VectorXd& true_vacuum, const Eigen::VectorXd& false_vacuum) const;
   
   /** Number of scalar fields that could break electroweak symmetry */
   PROPERTY(int, n_ew_scalars, -1)

--- a/src/phase_finder.cpp
+++ b/src/phase_finder.cpp
@@ -65,7 +65,7 @@ std::vector<Eigen::VectorXd> PhaseFinder::generate_test_points() const {
   return test_points;
 }
 
-std::vector<Point> PhaseFinder::find_minima_at_t(std::vector<Eigen::VectorXd> test_points, double T) const {
+std::vector<Point> PhaseFinder::find_minima_at_t(const std::vector<Eigen::VectorXd>& test_points, double T) const {
   std::vector<Point> minima;
 
   for (const auto& p : test_points) {
@@ -86,7 +86,7 @@ std::vector<Point> PhaseFinder::find_minima_at_t(std::vector<Eigen::VectorXd> te
   return minima;
 }
 
-bool PhaseFinder::consistent_vacuum(Eigen::VectorXd x) const {
+bool PhaseFinder::consistent_vacuum(const Eigen::VectorXd& x) const {
   if (n_ew_scalars == 0) {
     return true;
   }
@@ -94,7 +94,7 @@ bool PhaseFinder::consistent_vacuum(Eigen::VectorXd x) const {
   return std::abs(found - v) < x_abs_identical;
 }
 
-std::vector<Eigen::VectorXd> PhaseFinder::symmetric_partners(const Eigen::VectorXd a) const {
+std::vector<Eigen::VectorXd> PhaseFinder::symmetric_partners(const Eigen::VectorXd& a) const {
   std::vector<Eigen::VectorXd> partners;
   partners.push_back(a);
   for (size_t i=0; i < P.apply_symmetry(a).size(); i++) {
@@ -108,7 +108,7 @@ std::vector<Eigen::VectorXd> PhaseFinder::symmetric_partners(const Eigen::Vector
   return partners;
 }
 
-bool PhaseFinder::identical_within_tol(const Eigen::VectorXd a, const Eigen::VectorXd b) const {
+bool PhaseFinder::identical_within_tol(const Eigen::VectorXd& a, const Eigen::VectorXd& b) const {
   double min_distance = (a-b).norm();
   for (const auto b_ : symmetric_partners(b)) {
     min_distance = std::min(min_distance, (a-b_).norm());
@@ -116,11 +116,11 @@ bool PhaseFinder::identical_within_tol(const Eigen::VectorXd a, const Eigen::Vec
   return min_distance < x_abs_identical + x_rel_identical * std::max(a.norm(), b.norm());
 }
 
-bool PhaseFinder::jump(const Eigen::VectorXd a, const Eigen::VectorXd b) const {
+bool PhaseFinder::jump(const Eigen::VectorXd& a, const Eigen::VectorXd& b) const {
   return (a - b).norm() > x_abs_jump + x_rel_jump * std::max(a.norm(), b.norm());
 }
 
-Point PhaseFinder::get_deepest_minima(const std::vector<Point> minima, double T) const {
+Point PhaseFinder::get_deepest_minima(const std::vector<Point>& minima, double T) const {
   std::vector<double> potential;
   for (const auto &m : minima) {
     potential.push_back(m.potential);
@@ -137,7 +137,7 @@ Point PhaseFinder::get_deepest_minima(const std::vector<Point> minima, double T)
   return deepest;
 }
 
-minima_descriptor PhaseFinder::get_minima_descriptor(const Point minima) const {
+minima_descriptor PhaseFinder::get_minima_descriptor(const Point& minima) const {
   if (identical_within_tol(minima.x, Eigen::VectorXd::Zero(n_scalars))) {
     return ORIGIN;
   }
@@ -147,12 +147,12 @@ minima_descriptor PhaseFinder::get_minima_descriptor(const Point minima) const {
   return OTHER;
 }
 
-minima_descriptor PhaseFinder::get_minima_descriptor(const std::vector<Point> minima, double T) const {
+minima_descriptor PhaseFinder::get_minima_descriptor(const std::vector<Point>& minima, double T) const {
   const Point deepest = get_deepest_minima(minima, T);
   return get_minima_descriptor(deepest);
 }
 
-bool PhaseFinder::origin_unique_minima(const std::vector<Point> minima) const {
+bool PhaseFinder::origin_unique_minima(const std::vector<Point>& minima) const {
   for (const auto &m : minima) {
     if (!identical_within_tol(m.x, Eigen::VectorXd::Zero(n_scalars))) {
       return false;
@@ -161,13 +161,13 @@ bool PhaseFinder::origin_unique_minima(const std::vector<Point> minima) const {
   return true;
 }
 
-bool PhaseFinder::belongs_known_phase(Point point) const {
+bool PhaseFinder::belongs_known_phase(const Point& point) const {
   for (const auto& phase : phases) {
     if (!phase.contains_t(point.t)) {
       continue;
     }
 
-    const Eigen::VectorXd x = phase_at_T(&phase, point.t).x;
+    const Eigen::VectorXd x = phase_at_T(phase, point.t).x;
     if (identical_within_tol(x, point.x)) {
       return true;
     }
@@ -515,21 +515,21 @@ phase_end_descriptor PhaseFinder::trace_minimum(Point start, double tstop,
   throw std::runtime_error("This should be unreachable");
 }
 
-bool PhaseFinder::hessian_singular(Eigen::VectorXd X, double T) const {
+bool PhaseFinder::hessian_singular(const Eigen::VectorXd& X, double T) const {
   return hessian_singular(P.d2V_dx2(X, T), X, T);
 }
 
-bool PhaseFinder::hessian_singular(Eigen::MatrixXd hessian, Eigen::VectorXd X, double T) const {
+bool PhaseFinder::hessian_singular(const Eigen::MatrixXd& hessian, const Eigen::VectorXd& X, double T) const {
   const double t_min = hessian.eigenvalues().cwiseAbs().minCoeff();
   const double zero_t_min = P.d2V_dx2(X, 0.).eigenvalues().cwiseAbs().minCoeff();
   return std::abs(t_min) < hessian_singular_rel_tol * std::abs(zero_t_min);
 }
 
-bool PhaseFinder::hessian_positive_definite(Eigen::VectorXd X, double T) const {
+bool PhaseFinder::hessian_positive_definite(const Eigen::VectorXd& X, double T) const {
   return hessian_positive_definite(P.d2V_dx2(X, T), X, T);
 }
 
-bool PhaseFinder::hessian_positive_definite(Eigen::MatrixXd hessian, Eigen::VectorXd X, double T) const {
+bool PhaseFinder::hessian_positive_definite(const Eigen::MatrixXd& hessian, const Eigen::VectorXd& X, double T) const {
   auto eivals = hessian.eigenvalues();
   for (int i = 0; i < eivals.size(); i++) {
     if (eivals[i].imag() != 0. || eivals[i].real() < 0.) {
@@ -539,11 +539,11 @@ bool PhaseFinder::hessian_positive_definite(Eigen::MatrixXd hessian, Eigen::Vect
   return true;
 }
 
-Eigen::VectorXd PhaseFinder::dx_min_dt(Eigen::VectorXd X, double T) const {
+Eigen::VectorXd PhaseFinder::dx_min_dt(const Eigen::VectorXd& X, double T) const {
   return dx_min_dt(P.d2V_dx2(X, T), X, T);
 }
 
-Eigen::VectorXd PhaseFinder::dx_min_dt(Eigen::MatrixXd hessian, Eigen::VectorXd X, double T) const {
+Eigen::VectorXd PhaseFinder::dx_min_dt(const Eigen::MatrixXd& hessian, const Eigen::VectorXd& X, double T) const {
   const Eigen::VectorXd b = -P.d2V_dxdt(X, T);
   const Eigen::VectorXd dxdt = hessian.colPivHouseholderQr().solve(b);
   const bool check = b.isApprox(hessian * dxdt, linear_algebra_rel_tol);
@@ -555,15 +555,15 @@ Eigen::VectorXd PhaseFinder::dx_min_dt(Eigen::MatrixXd hessian, Eigen::VectorXd 
   return dxdt;
 }
 
-Point PhaseFinder::find_min(const Eigen::VectorXd guess, double T) const {
+Point PhaseFinder::find_min(const Eigen::VectorXd& guess, double T) const {
   return find_min(guess, T, Eigen::VectorXd::Constant(n_scalars, find_min_trace_abs_step));
 }
 
-Point PhaseFinder::find_min(const Eigen::VectorXd guess, double T, double abs_step) const {
+Point PhaseFinder::find_min(const Eigen::VectorXd& guess, double T, double abs_step) const {
   return find_min(guess, T, Eigen::VectorXd::Constant(n_scalars, abs_step));
 }
 
-Point PhaseFinder::find_min(const Eigen::VectorXd guess, double T, Eigen::VectorXd step) const {
+Point PhaseFinder::find_min(const Eigen::VectorXd& guess, double T, Eigen::VectorXd step) const {
   if (out_of_bounds(guess)) {
     LOG(fatal) << "guess = " << guess << " was out of bounds";
     throw std::runtime_error("guess for nlopt was out of bounds");
@@ -585,7 +585,7 @@ Point PhaseFinder::find_min(const Eigen::VectorXd guess, double T, Eigen::Vector
 
   opt.set_initial_step(step_vector);
 
-  std::function<double(Eigen::VectorXd)> objective = [this, T](Eigen::VectorXd x) {
+  std::function<double(const Eigen::VectorXd&)> objective = [this, T](const Eigen::VectorXd& x) {
     return this->P.V(x, T);
   };
 
@@ -632,26 +632,26 @@ Point PhaseFinder::find_min(const Eigen::VectorXd guess, double T, Eigen::Vector
   return {minima_VectorXd, potential_at_minima, T};
 }
 
-Point PhaseFinder::phase_at_T(const Phase *phase, double T) const {
-  if (T >= phase->T.back()) {
-    return {phase->X.back(), phase->V.back(), T};
+Point PhaseFinder::phase_at_T(const Phase& phase, double T) const {
+  if (T >= phase.T.back()) {
+    return {phase.X.back(), phase.V.back(), T};
   }
-  if (T <= phase->T.front()) {
-    return {phase->X.front(), phase->V.front(), T};
+  if (T <= phase.T.front()) {
+    return {phase.X.front(), phase.V.front(), T};
   }
 
-  size_t n = std::lower_bound(phase->T.begin(), phase->T.end(), T) - phase->T.begin();
+  size_t n = std::lower_bound(phase.T.begin(), phase.T.end(), T) - phase.T.begin();
   if (n > 0) {
-    n = phase->T[n] - T < T - phase->T[n - 1] ? n : n - 1;
+    n = phase.T[n] - T < T - phase.T[n - 1] ? n : n - 1;
   }
 
-  const double dt_start = T - phase->T[n];
+  const double dt_start = T - phase.T[n];
   std::vector<Eigen::VectorXd> X;
   std::vector<double> T_;
   std::vector<Eigen::VectorXd> dXdT;
   std::vector<double> V;
   Point jumped;
-  const Point start = {phase->X[n], phase->V[n], phase->T[n]};
+  const Point start = {phase.X[n], phase.V[n], phase.T[n]};
   auto end = trace_minimum(start, T, dt_start, &X, &T_, &dXdT, &V, &jumped);
   if (end != REACHED_T_STOP) {
     LOG(warning) << "Expected to reach tstop but end = " << end;
@@ -659,11 +659,11 @@ Point PhaseFinder::phase_at_T(const Phase *phase, double T) const {
   return {X.back(), V.back(), T};
 }
 
-bool PhaseFinder::redundant(const Phase *phase1, const Phase *phase2, end_descriptor end) const {
-  const double tmax_1 = phase1->T.back();
-  const double tmin_1 = phase1->T.front();
-  const double tmax_2 = phase2->T.back();
-  const double tmin_2 = phase2->T.front();
+bool PhaseFinder::redundant(const Phase& phase1, const Phase& phase2, end_descriptor end) const {
+  const double tmax_1 = phase1.T.back();
+  const double tmin_1 = phase1.T.front();
+  const double tmax_2 = phase2.T.back();
+  const double tmin_2 = phase2.T.front();
 
   const double tmax = std::min(tmax_1, tmax_2);
   const double tmin = std::max(tmin_1, tmin_2);
@@ -719,7 +719,7 @@ void PhaseFinder::remove_redundant() {
 
         LOG(debug) << "Checking redundancy between phases " << phase1.key << " and " << phase2.key;
 
-        if (redundant(&phase1, &phase2)) {
+        if (redundant(phase1, phase2)) {
           LOG(debug) << "Phases " << phase1.key << " and " << phase2.key
                      << " are redundant";
           changed = true;
@@ -759,7 +759,7 @@ void PhaseFinder::remove_redundant() {
 }
 
 
-bool PhaseFinder::out_of_bounds(Eigen::VectorXd x) const {
+bool PhaseFinder::out_of_bounds(const Eigen::VectorXd& x) const {
   std::vector<double> vector_x(x.data(), x.data() + x.rows() * x.cols());
   return (vector_x <= lower_bounds) || (vector_x >= upper_bounds);
 }

--- a/src/transition_finder.cpp
+++ b/src/transition_finder.cpp
@@ -32,7 +32,7 @@ std::vector<Transition> TransitionFinder::find_transition(Phase phase1, Phase ph
   }
 
   try {
-    const auto f = [this, phase1, phase2](double T) {return this->pf.delta_potential_at_T(&phase1, &phase2, T);};
+    const auto f = [this, phase1, phase2](double T) {return this->pf.delta_potential_at_T(phase1, phase2, T);};
 
     const double root_bits = 1. - std::log2(TC_tol_rel);
     boost::math::tools::eps_tolerance<double> stop(root_bits);
@@ -46,8 +46,8 @@ std::vector<Transition> TransitionFinder::find_transition(Phase phase1, Phase ph
     if (!ordered) {
       std::swap(phase1, phase2);
     }
-    const auto phase1_at_critical = pf.phase_at_T(&phase1, TC);
-    const auto phase2_at_critical = pf.phase_at_T(&phase2, TC);
+    const auto phase1_at_critical = pf.phase_at_T(phase1, TC);
+    const auto phase2_at_critical = pf.phase_at_T(phase2, TC);
     const auto delta_potential = phase1_at_critical.potential - phase2_at_critical.potential;
     const auto true_vacua = pf.symmetric_partners(phase1_at_critical.x);
     const auto false_vacua =  pf.symmetric_partners(phase2_at_critical.x);
@@ -86,24 +86,24 @@ std::vector<Transition> TransitionFinder::find_transition(Phase phase1, Phase ph
   }
 }
 
-std::vector<Transition> TransitionFinder::divide_and_find_transition(Phase phase1, Phase phase2, double T1, double T2) const {
+std::vector<Transition> TransitionFinder::divide_and_find_transition(const Phase& phase1, const Phase& phase2, double T1, double T2) const {
   std::vector<Transition> roots;
   for (double T = T1; T <= T2; T += separation) {
     const auto bs = find_transition(phase1, phase2, T, std::min(T + separation, T2));
-    for (auto &b : bs) {
+    for (const auto &b : bs) {
       roots.push_back(b);
     }
   }
   return roots;
 }
 
-double TransitionFinder::gamma(const Eigen::VectorXd true_vacuum, const Eigen::VectorXd false_vacuum, const double TC) const {
+double TransitionFinder::gamma(const Eigen::VectorXd& true_vacuum, const Eigen::VectorXd& false_vacuum, const double TC) const {
   const int b = true_vacuum.size() + 1;
   const int items = (b + (n_ew_scalars % b)) % b;
   return (true_vacuum-false_vacuum).head(items).norm()/TC;
 }
 
-std::vector<bool> TransitionFinder::changed(const Eigen::VectorXd true_vacuum, const Eigen::VectorXd false_vacuum) const {
+std::vector<bool> TransitionFinder::changed(const Eigen::VectorXd& true_vacuum, const Eigen::VectorXd& false_vacuum) const {
   auto delta = true_vacuum-false_vacuum;
   std::vector<bool> changed_;
   for (unsigned int i = 0; i < delta.size(); i += 1) {
@@ -112,11 +112,11 @@ std::vector<bool> TransitionFinder::changed(const Eigen::VectorXd true_vacuum, c
   return changed_;
 }
 
-bool TransitionFinder::phases_overlaped(Phase phase1, Phase phase2, double T) const {
-  return pf.identical_within_tol(pf.phase_at_T(&phase1, T).x, pf.phase_at_T(&phase2, T).x);
+bool TransitionFinder::phases_overlaped(const Phase& phase1, const Phase& phase2, double T) const {
+  return pf.identical_within_tol(pf.phase_at_T(phase1, T).x, pf.phase_at_T(phase2, T).x);
 }
 
-std::vector<double> TransitionFinder::get_un_overlapped_T_range(Phase phase1, Phase phase2, double T1, double T2) const {
+std::vector<double> TransitionFinder::get_un_overlapped_T_range(const Phase& phase1, const Phase& phase2, double T1, double T2) const {
   std::vector<double> T_range;
   
   if (!(phases_overlaped(phase1, phase2, T1) || phases_overlaped(phase1, phase2, T2))) {
@@ -157,8 +157,8 @@ void TransitionFinder::find_transitions() {
   calculated_transitions = true;
   const auto phases = pf.get_phases();
 
-  for (auto &phase1 : phases) {
-    for (auto &phase2 : phases) {
+  for (const auto &phase1 : phases) {
+    for (const auto &phase2 : phases) {
       // Don't investigate n1 -> n1 or n1 -> n2 as well as n2 -> n1
       if (phase1.key >= phase2.key) {
         continue;
@@ -182,8 +182,8 @@ void TransitionFinder::find_transitions() {
       if (T_range.size() == 3) {
         const auto TC = T_range[2];
         LOG(debug) << "Phases " << phase1.key << " and " << phase2.key << " cross at T=" << TC;
-        const auto phase1_at_critical = pf.phase_at_T(&phase1, TC);
-        const auto phase2_at_critical = pf.phase_at_T(&phase2, TC);
+        const auto phase1_at_critical = pf.phase_at_T(phase1, TC);
+        const auto phase2_at_critical = pf.phase_at_T(phase2, TC);
         const double gamma_ = 0.;
         auto changed_ = changed(phase1_at_critical.x, phase2_at_critical.x);
         Transition f = {SUCCESS, TC, phase1, phase2, 
@@ -197,7 +197,7 @@ void TransitionFinder::find_transitions() {
         find_transition(phase1, phase2, T_range[0], T_range[1]) :
         divide_and_find_transition(phase1, phase2, T_range[0], T_range[1]);
 
-      for (auto &f : found) {
+      for (const auto &f : found) {
         if (f.message == SUCCESS) {
             transitions.push_back(f);
         }
@@ -221,7 +221,7 @@ std::ostream& operator << (std::ostream& o, const TransitionFinder& a) {
       o << "s";
     }
     o << std::endl << std::endl;
-    for (auto &t : a.transitions) {
+    for (const auto &t : a.transitions) {
       o << t << std::endl;
     }
   }

--- a/src/transition_finder.cpp
+++ b/src/transition_finder.cpp
@@ -23,8 +23,6 @@
 
 namespace PhaseTracer {
 
-TransitionFinder::TransitionFinder(PhaseFinder &pf_) : pf(pf_) {}
-
 std::vector<Transition> TransitionFinder::find_transition(Phase phase1, Phase phase2, double T1, double T2) const {
   if (T1 > T2) {
     LOG(debug) << "Phases do not overlap in temperature - no critical temperature";


### PR DESCRIPTION
Also use `for (const auto&` where appropriate. I didn't acutally see any places where passing by non-cons ref occurred or add any. We use pointers in those situations, which actually I prefer as the fact that the value is changing is more obvious to the called as they pass a pointer or have to add the ampersand `&my_variable`, which makes it clearer to me that it may be changed by the function.