### PR TITLE
Bug fix in phase_plotter.py for newer matplotlib versions

### DIFF
--- a/make_plots/phase_plotter.py
+++ b/make_plots/phase_plotter.py
@@ -131,7 +131,7 @@ def plane_phi_phi_one(pi, pj, phases, transitions, pdf_name="plane.pdf"):
 
     # Get size of legend
     plt.gcf().canvas.draw()
-    extent = leg.get_window_extent().inverse_transformed(ax.transAxes)
+    extent = leg.get_window_extent().transformed(ax.transAxes.inverted())
     dy = extent.y1 - extent.y0
 
     # Add it to axis limit


### PR DESCRIPTION
Replaced a function call `inverse_transformed` that was deprecated in newer versions of matplotlib (I think from version 3.3.0 on).