### PR TITLE
catch pathological potential earlier and give sensible error

### DIFF
--- a/src/phase_finder.cpp
+++ b/src/phase_finder.cpp
@@ -19,6 +19,7 @@
 #include "phase_finder.hpp"
 #include "pow.hpp"
 
+#include <cmath>
 #include <boost/math/special_functions/sign.hpp>
 #include <eigen3/Eigen/Eigenvalues>
 
@@ -227,6 +228,12 @@ void PhaseFinder::find_phases() {
 
   LOG(debug) << "Check potential at T = t_low = " << t_low;
   minima_at_t_low = find_minima_at_t(t_low);
+
+  for (const auto &minimum : minima_at_t_low) {
+    if (!std::isfinite(minimum.potential)) {
+      throw std::runtime_error("Invalid minimum found at t_low: non-finite potential");
+    }
+  }
 
   if (check_vacuum_at_low) {
     const minima_descriptor location = get_minima_descriptor(minima_at_t_low, t_low);


### PR DESCRIPTION
In 3deft models we need to set t_low non-zero. I forgot this and had a model failing with dxdt error when the root cause was an infinite potential at T=0.   We can't stop user stupidity  but i think catching it earlier would make it easier to spot.