### PR TITLE
Fix/endpoint extension distant minima

### DIFF
--- a/include/transition_finder.hpp
+++ b/include/transition_finder.hpp
@@ -21,6 +21,7 @@
 #include <algorithm>
 #include <ostream>
 #include <fstream>
+#include <limits>
 #include <string>
 #include <vector>
 
@@ -59,13 +60,13 @@ struct Transition {
   size_t key;
   size_t id;
 
-  double TN;
+  double TN = std::numeric_limits<double>::quiet_NaN();
   Eigen::VectorXd true_vacuum_TN;
   Eigen::VectorXd false_vacuum_TN;
   bool subcritical = false;
 
   PolynomialFitterEigen action_curve;
-  double TP;
+  double TP = std::numeric_limits<double>::quiet_NaN();
 
   Transition(Message message) : message(message) {};
 

--- a/src/path_deformation.cpp
+++ b/src/path_deformation.cpp
@@ -165,6 +165,10 @@ double SplinePath::find_loc_min_w_guess(Eigen::VectorXd p0, Eigen::VectorXd dp0,
   double fmin;
   optimizer.optimize(xmin, fmin);
 
+  const double local_minimum_bound = 0.25;
+  const double max_unchecked_endpoint_extension = 3. * local_minimum_bound;
+  bool retry_locally = std::abs(xmin[0] - guess) > max_unchecked_endpoint_extension;
+
   if (avoid_symmetric_partner != nullptr) {
     const Eigen::VectorXd candidate = p0 + xmin[0] * dp0;
     PhaseFinder phase_finder(P);
@@ -173,14 +177,15 @@ double SplinePath::find_loc_min_w_guess(Eigen::VectorXd p0, Eigen::VectorXd dp0,
                                     phase_finder.get_x_rel_identical() *
                                         std::max(candidate.norm(), avoid_symmetric_partner->norm());
     const bool same_point = direct_distance < direct_tolerance;
-    if (!phase_finder.identical_within_tol(candidate, *avoid_symmetric_partner) || same_point) {
-      return xmin[0];
+    if (phase_finder.identical_within_tol(candidate, *avoid_symmetric_partner) && !same_point) {
+      retry_locally = true;
     }
-  } else {
+  }
+
+  if (!retry_locally) {
     return xmin[0];
   }
 
-  const double local_minimum_bound = 0.25;
   const double lower_bound = guess - local_minimum_bound;
   const double upper_bound = guess + local_minimum_bound;
   optimizer.set_lower_bounds(std::vector<double>{lower_bound});
@@ -206,10 +211,10 @@ double SplinePath::find_loc_min_w_guess(Eigen::VectorXd p0, Eigen::VectorXd dp0,
     maximum_optimizer.optimize(xmax, fmax_neg);
 
     if (std::abs(xmax[0] - guess) < boundary_tol) {
-      throw std::runtime_error("Endpoint extension minimum is not locally bracketed.");
+      return guess;
     }
     if (std::abs(xmax[0] - boundary) < boundary_tol) {
-      throw std::runtime_error("Endpoint extension barrier is not locally bracketed.");
+      return guess;
     }
 
     optimizer.set_lower_bounds(std::vector<double>{std::min(guess, xmax[0])});


### PR DESCRIPTION
The previous fix only guarded against endpoint extension reaching a symmetric partner of the opposite endpoint. However, endpoint extension can also fail when the unconstrained 1D search finds a distant line minimum that is not identified as a symmetric partner.

This PR fixes that case by introducing a manually chosen safety threshold for endpoint extension. If the proposed extension is larger than this threshold, it is treated as unsafe and the code falls back to the existing local bracketing check. If no local minimum/barrier is bracketed, the endpoint is left unchanged.

The threshold is set manually.